### PR TITLE
[Bug] Overflow when updating bounds

### DIFF
--- a/simplifier/operations/bitwise.py
+++ b/simplifier/operations/bitwise.py
@@ -8,6 +8,7 @@ from operator import and_, lshift, neg, or_, rshift, xor
 from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Set, Tuple, Type, TypeVar, Union
 
 from simplifier.common import T
+from simplifier.operations.boolean import BOOLEAN_NEGATIONS, Relation
 from simplifier.operations.interface import AssociativeOperation, CommutativeOperation, OrderedOperation, UnaryOperation
 from simplifier.util.decorators import dirty
 from simplifier.world.nodes import BitVector, Constant, Operation, Variable, WorldObject
@@ -336,6 +337,8 @@ class CommonBitwiseAndOr(BitwiseOperation, CommutativeOperation, AssociativeOper
         if isinstance(term, BitwiseOr):
             operands = [op.operand if isinstance(op, BitwiseNegate) else self.world.bitwise_negate(op) for op in term.operands]
             return self.world.bitwise_and(*operands)
+        if isinstance(term, Relation):
+            return BOOLEAN_NEGATIONS[term.__class__](self.world).replace_operands(term.operands)
 
         return None
 

--- a/simplifier/operations/boolean.py
+++ b/simplifier/operations/boolean.py
@@ -5,12 +5,12 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Type, Union
 
 from simplifier.common import T
-from simplifier.operations import BitwiseAnd
 from simplifier.operations.interface import OrderedOperation, UnaryOperation
 from simplifier.util.decorators import dirty
 from simplifier.world.nodes import BitVector, Constant, Operation, WorldObject
 
 if TYPE_CHECKING:
+    from simplifier.operations import BitwiseAnd
     from simplifier.visitor import WorldObjectVisitor
 
 

--- a/simplifier/range_simplification_commons/expression_values.py
+++ b/simplifier/range_simplification_commons/expression_values.py
@@ -161,8 +161,10 @@ class ExpressionValues:
     def _refine_bounds_using_forbidden_values(self) -> None:
         """Refine the upper and lower bounds considering the forbidden values."""
         while self.upper_bound.contained_in(self.forbidden_values) or self.lower_bound.contained_in(self.forbidden_values):
-            self.upper_bound.modify_if_contained_in(self.forbidden_values, -1)
-            self.lower_bound.modify_if_contained_in(self.forbidden_values, 1)
+            if self.upper_bound.modify_if_contained_in(self.forbidden_values, -1):
+                self._add_must_value_if_values_are_equal(self.upper_bound, self.size_lower_bound)
+            if self.lower_bound.modify_if_contained_in(self.forbidden_values, 1):
+                self._add_must_value_if_values_are_equal(self.lower_bound, self.size_upper_bound)
 
     def _remove_redundant_forbidden_values(self) -> None:
         """Remove redundant forbidden values, i.e., values that are already forbidden due to the upper and lower bounds."""

--- a/tests/operations/test_bitwise.py
+++ b/tests/operations/test_bitwise.py
@@ -164,6 +164,14 @@ class TestBitwiseAnd:
             w.simplify()
             assert World.compare(v, w.from_string("(& (| (~ x@1) (~ y@1) ) z@1)"))
 
+        def test_associative_fold_8(self):
+            """(v < 4) & ((v >= 4) | (x == 3 & y == 2)) = (v < 4) & (x == 3) & (y == 2)"""
+            w = World()
+            cond = w.from_string("(& (u< v@4 4@4) (| (u>= v@4 4@4) (& (== x@4 3@4) (== y@4 2@4))) )")
+            w.define(var := w.variable("var", 1), cond)
+            w.simplify()
+            assert World.compare(var, w.from_string("(& (u< v@4 4@4) (== x@4 3@4) (== y@4 2@4) )"))
+
     @pytest.mark.parametrize(
         "lhs, rhs",
         [

--- a/tests/operations/test_range_simplification.py
+++ b/tests/operations/test_range_simplification.py
@@ -454,3 +454,17 @@ def test_check_clean_up_works(test, result, numb_vertices):
 )
 def test_range_simplification_mixed_signedness(test, result):
     check_range_simplification(test, result)
+
+
+@pytest.mark.parametrize(
+    "test, result",
+    [
+        ("(& (u<= x@8 1@8) (!= x@8 1@8) (!= x@8 0@8))", "0@1"),
+        ("(& (u< x@8 1@8) (!= x@8 0@8))", "0@1"),
+        ("(& (u> x@3 5@3) (!= x@3 6@3) (!= x@3 7@3))", "0@1"),
+        ("(& (s< x@3 -2@3) (!= x@3 -3@3) (!= x@3 -4@3))", "0@1"),
+        ("(& (s>= x@3 2@3) (!= x@3 2@3) (!= x@3 3@3))", "0@1"),
+    ],
+)
+def test_range_simplification_out_of_bound(test, result):
+    check_range_simplification(test, result)


### PR DESCRIPTION
When updating bounds for relations, we did not check whether the bound is already equal to the size bound.
More precisely, when we have the lower bound 1 and the forbidden values 0 and 1, then we first update the bound to 1 (1 -1) and then to (0-1). For unsigned values, this would lead to the maximum value.

Additionally, we improve the folding by allowing to negate relations.